### PR TITLE
Make dtor of polymorphic 'Component' class virtual

### DIFF
--- a/engine/include/component.hpp
+++ b/engine/include/component.hpp
@@ -8,7 +8,7 @@ namespace pt
 class component
 {
 public:
-    ~component() = default;
+    virtual ~component() = default;
 
     virtual void start() {}
     virtual void update() {}


### PR DESCRIPTION
Consider making all the destructors of polymorphic classes either public virtual or protected nonvirtual. More on the topic: http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-nonvirtual